### PR TITLE
Remove PSSuspend requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,3 @@ This script was developed to facilitate the daily tasks of GTAV, avoid griefers 
 ### MAIN
 - Download AutoHotkey: https://www.autohotkey.com
   - Install AutoHotkey
-
-- Donwload PsTools: https://docs.microsoft.com/en-us/sysinternals/downloads/pstools
-  - Extract pssuspend.exe and pssuspend64.exe to C:\Windows
-  
-  - First time runing?? 
-    - RUN
-    - Type: pssuspend -r gta5
-    - Accept the license
-    - Now you are ready to execute on utility script

--- a/utility.ahk
+++ b/utility.ahk
@@ -70,24 +70,68 @@ N_E:
   Return
 ;---------------------END---------------------
 
-;TODO SUpend and Resume Process, Thanks: u/HyakoV2
+;TODO SUpend and Resume Process, Thanks: u/HyakoV2 & u/TDarkShadow
 ;------------SUSPEND SECTION - START----------
+
+; Suspends a process which has the given pid value.
+SuspendProcess(pid) {
+     hProcess := DllCall("OpenProcess", "UInt", 0x1F0FFF, "Int", 0, "Int", pid)
+     If (hProcess) {
+          DllCall("ntdll.dll\NtSuspendProcess", "Int", hProcess)
+          DllCall("CloseHandle", "Int", hProcess)
+     }
+  }
+  Return
+
+; Resumes a process which has the given pid value.
+ResumeProcess(pid) {
+     hProcess := DllCall("OpenProcess", "UInt", 0x1F0FFF, "Int", 0, "Int", pid)
+     If (hProcess) {
+          DllCall("ntdll.dll\NtResumeProcess", "Int", hProcess)
+          DllCall("CloseHandle", "Int", hProcess)
+     }
+  }
+  Return
+
+; Checks wether a process which has the given pid value is suspended (true) or not (false).
+IsProcessSuspended(pid) {
+     For thread in ComObjGet("winmgmts:").ExecQuery("Select * from Win32_Thread WHERE ProcessHandle = " pid)
+     If (thread.ThreadWaitReason != 5)
+     Return False
+     Return True
+  }
+  Return
 
 ;Suspend Process, wait 10 secondes, Resume Process
 P_S_W_R:
-  Run, pssuspend gta5,,hide
+  Process, Exist, GTA5.exe
+  pid := ErrorLevel
+  If (!IsProcessSuspended(pid)) {
+      SuspendProcess(pid)
+  }
   Sleep, ONE_SECOND * DELAY_SUSPEND
-  Run, pssuspend -r gta5,,hide
-  Return
+  Process, Exist, GTA5.exe
+  pid := ErrorLevel
+  If (IsProcessSuspended(pid)) {
+      ResumeProcess(pid)
+  }
 
 ;Suspend Process
 P_S:
-  Run, pssuspend gta5,,hide
+  Process, Exist, GTA5.exe
+  pid := ErrorLevel
+  If (!IsProcessSuspended(pid)) {
+      SuspendProcess(pid)
+  }
   Return
 
 ;Resume Process
 P_R:
-  Run, pssuspend -r gta5,,hide
+  Process, Exist, GTA5.exe
+  pid := ErrorLevel
+  If (IsProcessSuspended(pid)) {
+      ResumeProcess(pid)
+  }
   Return
 ;---------------------END---------------------
 

--- a/utility.ahk
+++ b/utility.ahk
@@ -115,6 +115,7 @@ P_S_W_R:
   If (IsProcessSuspended(pid)) {
       ResumeProcess(pid)
   }
+  Return
 
 ;Suspend Process
 P_S:


### PR DESCRIPTION
Changed the required use of PSSuspend to a Windows native solution.
I use this tweak in my own little AutoHotkey GTA:O toolbox because I didn't like to use any external tools.
It's also not the best of coding but it's quite robust.
Only tested on Windows 10 build 18363 and Windows 10 build 19041.